### PR TITLE
found an app inconsistency on the theme picker button

### DIFF
--- a/bugs/Bug-007.md
+++ b/bugs/Bug-007.md
@@ -1,0 +1,34 @@
+# Bug ID: Bug-007
+
+# Title:
+    Application inconsistency on the theme picker button
+
+# module:
+    UI/Kitchen
+
+# Severity:
+    Medium
+
+# Priority:
+    Medium
+
+# Environment:
+    Android
+
+# Steps to reproduce:
+    1. login to the app
+    2. click the login menu at the bottom of the app
+    3. set the theme button to dark-blue-gray
+    4. take note of the theme button and how it is placed
+    5. click the more button at the bottom
+    6. click the recipe menu
+
+# Actual Result:
+    --> The theme picker button becomes large and overflows the screen
+
+# Expected Result:
+    --> The theme picker should be placed in the same position as the ktichen menu
+    --> The theme picker should be of the same size as that of the kitchen
+
+
+


### PR DESCRIPTION
if you click the kitchen menu and set the theme to dark-blue-gray the button is just well positioned. if you go to other
menus like recipes the same button overflows out of the screen and becomes bigger
